### PR TITLE
Adding retries to fetch + general logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ The `output folder` argument specifies the path to the folder where the HTML fil
 The `display by` argument can be set to `filters` or `entries` where the former displays results grouped by filters
 (entries may appear multiple times) and the latter displays each entry exactly once and summarises the relevant filters.
 
+There is an optional argument `max retries` for `run settings` which allows the user to set the maximally allowed retries per search chunk.
+If no value is passed, the default is set to `3`.
+
 ### Data
 
 **Example:**

--- a/example/run_config.yml
+++ b/example/run_config.yml
@@ -1,6 +1,7 @@
 run settings:
   output folder: example/output
   display by: filters
+  max retries: 5
 data:
   categories:
     - math.RT

--- a/example/run_config.yml
+++ b/example/run_config.yml
@@ -1,7 +1,6 @@
 run settings:
   output folder: example/output
   display by: filters
-  max retries: 5
 data:
   categories:
     - math.RT

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas==2.2.3
 PyYAML==6.0.2
 requests==2.32.3
 yattag==1.16.1
+tqdm==4.67.1

--- a/src/format.py
+++ b/src/format.py
@@ -32,10 +32,11 @@ def format_entries_as_html(
                 with tag("div", klass="header"):
                     text("arXiv Results")
                 with tag("div", klass="subheader"):
+                    doc.asis("<br>")
+                    text(", ".join(categories))
+                    doc.asis("<br><br>")
                     text(
-                        ", ".join(categories)
-                        + ": "
-                        + start_date.strftime("%d.%m.%Y")
+                        start_date.strftime("%d.%m.%Y")
                         + " - "
                         + end_date.strftime("%d.%m.%Y")
                     )


### PR DESCRIPTION
* Code has enhanced logic to wait for the retry the API in case of bad responses
  * Includes an optional argument `max retries` mentioned in the `README.md`
* Logging has been added to inform the user of the number of days fetched as well as general logging of steps